### PR TITLE
Removed Spring scanner

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,6 @@
         <bamboo.version>9.0.4</bamboo.version>
         <bamboo.data.version>${bamboo.version}</bamboo.data.version>
         <plugin.testrunner.version>2.0.2</plugin.testrunner.version>
-        <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
         <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>
         <slf4j.version>2.0.9</slf4j.version>
         <compiler.version>1.8</compiler.version>
@@ -139,18 +138,6 @@
             <artifactId>slf4j-reload4j</artifactId>
             <version>${slf4j.version}</version>
             <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.atlassian.plugin</groupId>
-            <artifactId>atlassian-spring-scanner-annotation</artifactId>
-            <version>${atlassian.spring.scanner.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.atlassian.plugin</groupId>
-            <artifactId>atlassian-spring-scanner-runtime</artifactId>
-            <version>${atlassian.spring.scanner.version}</version>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>javax.inject</groupId>


### PR DESCRIPTION
This PR removes the spring scanner, as it seems that it is not required

- [x] Unit tests passes
- [x] Plugin starts in local environment
- [x] Plugin tested locally
![grafik](https://github.com/FOCONIS/allure-bamboo/assets/5530228/30d9b7d5-af49-4366-bae5-58338e9808b2)
- [ ] PR to upstream